### PR TITLE
Allow headers to be set via opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Where `subscriptions` and `customers` are [REST API resources](https://stripe.co
 If you prefer to work with a higher-level library, check out
 "stripity_stripe" or "stripe_elixir" on Hex.
 
+An optional 4th parameter can be supplied (a Keyword list of options):
+
+```elixir
+Stripy.req(:post, "charges", %{amount: 1000, currency: "USD"},
+  [stripe_account: "acct_12345678",
+   version: "2017-06-05",
+   secret_key: "sk_12345679",
+   idempotency_key: "123456"])
+```
+
 ## Installation
 
 Add to your `mix.exs` as usual:

--- a/lib/stripy.ex
+++ b/lib/stripy.ex
@@ -24,11 +24,38 @@ defmodule Stripy do
   check out "stripity_stripe" or "stripe_elixir" on Hex.
   """
 
-  @doc "Constructs HTTPoison header list with auth."
-  def headers(%{secret_key: sk, version: v}) do
-    [{"Authorization", "Bearer #{sk}"},
-     {"Content-Type", "application/x-www-form-urlencoded"},
-     {"Stripe-Version", v}]
+  @doc """
+  Constructs HTTPoison header list.
+
+  ## Options
+
+   * `:secret_key` - Sets the `Authorization` header with a stripe Secret Key
+    for this request
+
+   * `:version` - override the `Stripe-Version` header, defaults to `2017-06-05`
+
+   * `:stripe_account` - sets the `Stripe-Account` header for use with
+    [Stripe Connect](https://stripe.com/docs/connect/authentication#stripe-account-header)
+
+   * `:idempotency_key` - sets the
+    [`Idempotency-Key` header](https://stripe.com/docs/api/idempotent_requests)
+  """
+  def headers(params) do
+    base_headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
+
+    Enum.reduce(params, base_headers, fn
+      {:secret_key, sk}, headers ->
+        [{"Authorization", "Bearer #{sk}"} | headers]
+
+      {:version, v}, headers ->
+        [{"Stripe-Version", v} | headers]
+
+      {:stripe_account, id}, headers ->
+        [{"Stripe-Account", id} | headers]
+
+      {:idempotency_key, key}, headers ->
+        [{"Idempotency-Key", key} | headers]
+    end)
   end
 
   @doc "Constructs url with query params from given data."
@@ -42,6 +69,8 @@ defmodule Stripy do
   Will return an HTTPoison standard response; see `parse/1`
   for decoding the response body.
 
+  See `headers/1` for a list of options.
+
   ## Examples
       iex> Stripy.req(:get, "subscriptions")
       {:ok, %HTTPoison.Response{...}}
@@ -49,15 +78,18 @@ defmodule Stripy do
       iex> Stripy.req(:post, "customers", %{"email" => "a@b.c", "metadata[user_id]" => 1})
       {:ok, %HTTPoison.Response{...}}
   """
-  def req(action, resource, data \\ %{}) when action in [:get, :post, :delete] do
+  def req(action, resource, data \\ %{}, opts \\ []) when action in [:get, :post, :delete] do
     if Application.get_env(:stripy, :testing, false) do
       mock_server = Application.get_env(:stripy, :mock_server, Stripy.MockServer)
       mock_server.request(action, resource, data)
     else
-      header_params = %{
-        secret_key: Application.fetch_env!(:stripy, :secret_key),
-        version: Application.get_env(:stripy, :version, "2017-06-05")
-      }
+      header_params =
+        [
+          secret_key: Application.fetch_env!(:stripy, :secret_key),
+          version: Application.get_env(:stripy, :version, "2017-06-05")
+        ]
+        |> Keyword.merge(opts)
+
       api_url = Application.get_env(:stripy, :endpoint, "https://api.stripe.com/v1/")
       options = Application.get_env(:stripy, :httpoison, [])
 
@@ -70,9 +102,11 @@ defmodule Stripy do
   def parse({:ok, %{status_code: 200, body: body}}) do
     {:ok, Poison.decode!(body)}
   end
+
   def parse({:ok, %{body: body}}) do
     error = Poison.decode!(body) |> Map.fetch!("error")
     {:error, error}
   end
+
   def parse({:error, error}), do: {:error, error}
 end


### PR DESCRIPTION
There are two important headers that I need to be configurable: `Stripe-Account` (`:stripe_account`) for Stripe Connect and `Idempotency-Key` (`:idempotency_key`) for retrying POST requests. This PR makes those setable as well as making the existing headers overridable (`:version` as well as `:secret_key`)