### PR TITLE
Allow setting string configs via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ config :stripy,
   httpoison: [recv_timeout: 5000, timeout: 8000] # optional
 ```
 
+You may also use environment variables:
+
+``` elixir
+config :stripy,
+  secret_key: {:system, "STRIPE_SECRET_KEY"},
+  endpoint: {:system, "STRIPE_ENDPOINT"},
+  version: {:system, "STRIPE_VERSION"}
+```
+
 ## Testing
 
 You can disable actual calls to the Stripe API like so:

--- a/lib/stripy.ex
+++ b/lib/stripy.ex
@@ -57,18 +57,19 @@ defmodule Stripy do
       mock_server = Application.get_env(:stripy, :mock_server, Stripy.MockServer)
       mock_server.request(action, resource, data)
     else
-      secret_key = Application.fetch_env!(:stripy, :secret_key)
+      secret_key = get_config!(:secret_key)
 
       headers =
         @content_type_header
         |> Map.merge(%{
           "Authorization" => "Bearer #{secret_key}",
-          "Stripe-Version" => Application.get_env(:stripy, :version, "2017-06-05")
+          "Stripe-Version" => get_config(:version, "2017-06-05")
         })
         |> Map.merge(headers)
         |> Map.to_list()
 
-      api_url = Application.get_env(:stripy, :endpoint, "https://api.stripe.com/v1/")
+      api_url = get_config(:endpoint, "https://api.stripe.com/v1/")
+
       options = Application.get_env(:stripy, :httpoison, [])
 
       url = url(api_url, resource, data)
@@ -87,4 +88,16 @@ defmodule Stripy do
   end
 
   def parse({:error, error}), do: {:error, error}
+
+  defp get_config(key, default \\ nil) when is_atom(key) do
+    case Application.fetch_env(:stripy, key) do
+      {:ok, {:system, env_var}} -> System.get_env(env_var)
+      {:ok, value} -> value
+      :error -> default
+    end
+  end
+
+  defp get_config!(key) do
+    get_config(key) || raise "stripy config #{key} is required"
+  end
 end


### PR DESCRIPTION
Allowing configs to be set via `{:system, "VAR_NAME"}` has become conventional. Because the problem with this code below is that the config is compiled into the release:

```elixir
config :stripy,
  secret_key: System.get_env("STRIPE_SECRET_KEY")
```

With this code, it's read at runtime:

```elixir
config :stripy,
  secret_key: {:system, "STRIPE_SECRET_KEY"}
```

This is mainly important for the secret key variable, but other string variables may be set via environment now. This excludes `httpoison`, `testing` and `mock_server` configs